### PR TITLE
Fixed the Message No Edit Bug

### DIFF
--- a/events/events/messageUpdate.js
+++ b/events/events/messageUpdate.js
@@ -3,7 +3,8 @@ const { MessageEmbed } = require('discord.js')
 
 module.exports = (client) => {
     client.on('messageUpdate', (oldMessage, newMessage) => {
-        if(oldMessage.author.bot) return
+        if(oldMessage.author.bot) return;
+        if(oldMessage.content === newMessage.content) return;
         const channell = oldMessage.guild.channels.cache.find(ch => ch.name.includes("mod-logs")).id
 
         const logEmbed = new MessageEmbed()


### PR DESCRIPTION
People often open the message editing box on Discord by mistake, and when they exit, the event is fired. But it doesn't always lead to change in content or anything. So the bot often logs unnecessary stuff... 
This PR fixes that!